### PR TITLE
seg6: Support SRv6 for IPv6 Add/Del

### DIFF
--- a/rib/api.go
+++ b/rib/api.go
@@ -92,7 +92,7 @@ func IPv4RouteSeg6SegmentsApi(Cmd int, Args cmd.Args) int {
 	for _, arg := range Args {
 		segs = append(segs, arg.(net.IP))
 	}
-	fmt.Println("Static IPv4 seg6 segments:", prefix, nexthop, mode, segs)
+	//fmt.Println("Static IPv4 seg6 segments:", prefix, nexthop, mode, segs)
 	if Cmd == cmd.Set {
 		server.StaticSeg6SegmentsAdd(prefix, nexthop, mode, segs)
 	} else {
@@ -118,9 +118,15 @@ func IPv6RouteSeg6SegmentsApi(Cmd int, Args cmd.Args) int {
 	nexthop := Args[1].(net.IP)
 	mode := Args[2].(string)
 	Args = Args[3:]
-	fmt.Println("Static IPv6 seg6 segments:", prefix, nexthop, mode, Args)
+	segs := make([]net.IP, 0, len(Args))
+	for _, arg := range Args {
+		segs = append(segs, arg.(net.IP))
+	}
+	//fmt.Println("Static IPv6 seg6 segments:", prefix, nexthop, mode, segs)
 	if Cmd == cmd.Set {
+		server.StaticSeg6SegmentsAdd(prefix, nexthop, mode, segs)
 	} else {
+		server.StaticSeg6SegmentsDelete(prefix, nexthop, mode, segs)
 	}
 	return cmd.Success
 }

--- a/rib/rib.go
+++ b/rib/rib.go
@@ -483,7 +483,6 @@ func (v *Vrf) RibDelete(p *netutil.Prefix, ri *Rib) {
 	if n == nil {
 		return
 	}
-
 	if n.Item == nil {
 		fmt.Println("n.Item is nil, ", p, ri)
 		return


### PR DESCRIPTION
Add / delete SRv6 routes for IPv6. mode = encap/inline.
Confirmed route is installed/deleted from Linux Kernel using `ip -6 route`.

* Steps to install / delete routes.
```
ip address add 2001:db8::ff/64 dev lxcbr0
set routing-options ipv6 route-srv6 beef::/64 nexthop 2001:db8::1 seg6 encap segments c0be::1 c0be::2 c0be::3
set routing-options ipv6 route-srv6 c0be::/64 nexthop 2001:db8::1 seg6 inline segments c0be::1 c0be::2 c0be::3

run show ipv6 route
ip -6 route

delete routing-options ipv6 route-srv6 beef::/64
delete routing-options ipv6 route-srv6 c0be::/64

run show ipv6 route
ip -6 route
```

* Log after installing routes:
```
coreswitch#run show ipv6 route
Codes: K - kernel, C - connected, S - static, R - RIP, B - BGP
       O - OSPF, IA - OSPF inter area
       N1 - OSPF NSSA external type 1, N2 - OSPF NSSA external type 2
       E1 - OSPF external type 1, E2 - OSPF external type 2
       i - IS-IS, L1 - IS-IS level-1, L2 - IS-IS level-2, ia - IS-IS inter area

C     ::1/128 [0/0]
      via lo, directly connected
C     2001:db8::/64 [0/0]
      via lxcbr0, directly connected
S     beef::/64 [1/0]
      encap seg6 mode encap segs 3 [ c0be::1 c0be::2 c0be::3 ]
      via 2001:db8::1
S     c0be::/64 [1/0]
      encap seg6 mode inline segs 4 [ c0be::1 c0be::2 c0be::3 :: ]
      via 2001:db8::1
C     fe80::/64 [0/0]
      via enp0s3, directly connected
```